### PR TITLE
[Forked] [SPARK-53304][BUILD] Upgrade commons-text to 1.14.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -48,7 +48,7 @@ commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.18.0//commons-lang3-3.18.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.13.1//commons-text-1.13.1.jar
+commons-text/1.14.0//commons-text-1.14.0.jar
 compress-lzf/1.1.2//compress-lzf-1.1.2.jar
 curator-client/5.9.0//curator-client-5.9.0.jar
 curator-framework/5.9.0//curator-framework-5.9.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -665,7 +665,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.13.1</version>
+        <version>1.14.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
This PR is forked from: https://github.com/apache/spark/pull/52057

Original Description:
### What changes were proposed in this pull request?
This pr aims to upgarde Apache commons-text from 1.13.1 to 1.14.0.


### Why are the changes needed?
The full release notes as follows:
- https://github.com/apache/commons-text/blob/rel/commons-text-1.14.0/RELEASE-NOTES.txt


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No

Original Author: LuciferYang