### PR TITLE
[Forked] [SPARK-53392][ML][CONNECT] Move SpecializedArray handling to connect-common

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoSpecializedArray.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoSpecializedArray.scala
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.common
+
+import org.apache.spark.connect.proto
+
+private[spark] object ProtoSpecializedArray {
+
+  def toArray(array: proto.Bools): Array[Boolean] = {
+    val size = array.getValuesCount
+    if (size > 0) {
+      val a = Array.ofDim[Boolean](size)
+      var i = 0
+      while (i < size) {
+        a(i) = array.getValues(i)
+        i += 1
+      }
+      a
+    } else {
+      Array.emptyBooleanArray
+    }
+  }
+
+  def toArray(array: proto.Ints): Array[Int] = {
+    val size = array.getValuesCount
+    if (size > 0) {
+      val a = Array.ofDim[Int](size)
+      var i = 0
+      while (i < size) {
+        a(i) = array.getValues(i)
+        i += 1
+      }
+      a
+    } else {
+      Array.emptyIntArray
+    }
+  }
+
+  def toArray(array: proto.Longs): Array[Long] = {
+    val size = array.getValuesCount
+    if (size > 0) {
+      val a = Array.ofDim[Long](size)
+      var i = 0
+      while (i < size) {
+        a(i) = array.getValues(i)
+        i += 1
+      }
+      a
+    } else {
+      Array.emptyLongArray
+    }
+  }
+
+  def toArray(array: proto.Floats): Array[Float] = {
+    val size = array.getValuesCount
+    if (size > 0) {
+      val a = Array.ofDim[Float](size)
+      var i = 0
+      while (i < size) {
+        a(i) = array.getValues(i)
+        i += 1
+      }
+      a
+    } else {
+      Array.emptyFloatArray
+    }
+  }
+
+  def toArray(array: proto.Doubles): Array[Double] = {
+    val size = array.getValuesCount
+    if (size > 0) {
+      val a = Array.ofDim[Double](size)
+      var i = 0
+      while (i < size) {
+        a(i) = array.getValues(i)
+        i += 1
+      }
+      a
+    } else {
+      Array.emptyDoubleArray
+    }
+  }
+
+  def toArray(array: proto.Strings): Array[String] = {
+    val size = array.getValuesCount
+    if (size > 0) {
+      val a = Array.ofDim[String](size)
+      var i = 0
+      while (i < size) {
+        a(i) = array.getValues(i)
+        i += 1
+      }
+      a
+    } else {
+      Array.empty[String]
+    }
+  }
+
+  def fromArray(array: Array[Boolean]): proto.Bools = {
+    val builder = proto.Bools.newBuilder()
+    array.foreach(builder.addValues)
+    builder.build()
+  }
+
+  def fromArray(array: Array[Int]): proto.Ints = {
+    val builder = proto.Ints.newBuilder()
+    array.foreach(builder.addValues)
+    builder.build()
+  }
+
+  def fromArray(array: Array[Long]): proto.Longs = {
+    val builder = proto.Longs.newBuilder()
+    array.foreach(builder.addValues)
+    builder.build()
+  }
+
+  def fromArray(array: Array[Float]): proto.Floats = {
+    val builder = proto.Floats.newBuilder()
+    array.foreach(builder.addValues)
+    builder.build()
+  }
+
+  def fromArray(array: Array[Double]): proto.Doubles = {
+    val builder = proto.Doubles.newBuilder()
+    array.foreach(builder.addValues)
+    builder.build()
+  }
+
+  def fromArray(array: Array[String]): proto.Strings = {
+    val builder = proto.Strings.newBuilder()
+    array.foreach(builder.addValues)
+    builder.build()
+  }
+}


### PR DESCRIPTION
This PR is forked from: https://github.com/apache/spark/pull/52137

Original Description:
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Move SpecializedArray handling to connect-common


### Why are the changes needed?
`SpecializedArray` was defined in literal protos, move its utils to common for reuse

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no


Original Author: zhengruifeng