### PR TITLE
[Forked] [SPARK-53399][SQL] Improve CollapseProject

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
@@ -298,4 +298,20 @@ class CollapseProjectSuite extends PlanTest {
       comparePlans(optimized, expected)
     }
   }
+
+  test("SPARK-53399: Merge expressions") {
+    val query = testRelation
+      .select($"a" + 1 as "a_plus_1", $"b" + 1 as "b_plus_1")
+      .select($"a_plus_1" + $"a_plus_1", $"b_plus_1")
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = testRelation
+      .select($"a" + 1 as "a_plus_1", $"b")
+      .select($"a_plus_1" + $"a_plus_1", $"b" + 1 as "b_plus_1")
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
 }


### PR DESCRIPTION
Original Description:
### What changes were proposed in this pull request?

Latest improvements to `CollapseProject` rule (like https://github.com/apache/spark/pull/33958) prevented duplicating expressive expressons, which brings considerable performance improvement in many cases.
But there is one particular case when it can introduce significant perfoamance degradation. Consider a query where the adjacent project nodes don't get collapsed because they contain expensive, multiple referenced expressions, but the nodes also contain Python UDF expressions that otherwise wouldn't prevent project node collapsion. E.g.:
```
Project a + a as a_plus_a, PythonUDF(...) as udf2, udf1
  Project <expensive calculation> as a, PythonUDF(...) as udf1
    ...
```
In the above example the `CollapseProject` don't modify the 2 project nodes, which then causes 2 `BatchEvalPython` nodes to appear in the plan when `ExtractPythonUDFs` extracts them:
```
Project a + a as a_plus_a, udf2, udf1
  BatchEvalPython PythonUDF(...) -> udf2
    Project <expensive calculation> as a, udf1
      BatchEvalPython PythonUDF(...) -> udf1
        ...
```
The 2 `BatchEvalPython` nodes can cause significant serialization/deserialization overhead compared to the case when the original project nodes were collapsed and we had only 1 `BatchEvalPython` node.

The old behaviour can be restored with setting `spark.sql.optimizer.avoidCollapseUDFWithExpensiveExpr=true`, but it is still not ideal as we lose the perforamnce improvement in other cases.

This PR improves to the `CollapseProject` rule to not just collapse or don't collapse adjacent nodes, but be able to decide on individual expressions if it makes sense to merge them with expressions from the other node.

After this PR the new `CollapseProject` rule modifies the above plan as:
```
Project a + a as a_plus_a, PythonUDF(...) as udf2, PythonUDF(...) as udf1
  Project <expensive calculation> as a
    ...
```
that is then transformed to:
```
Project a + a as a_plus_a, udf2, udf1
  BatchEvalPython PythonUDF(...) -> udf2, PythonUDF(...) -> udf1
    Project <expensive calculation> as a
      ...
```

### Why are the changes needed?

To fix performance regression caused by `CollapseProject`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New and existing UTs.

### Was this patch authored or co-authored using generative AI tooling?

No.

Original Author: peter-toth