### PR TITLE
[Forked] [WIP][SPARK-55073] don't capture SparkPlan in EvalPythonUDTFExec

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
@@ -12,7 +12,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
+ * limitations under the License
  */
 
 package org.apache.spark.sql.execution.python


### PR DESCRIPTION
Original Description:
### What changes were proposed in this pull request?
`EvalPythonUDTFExec.execute()` can capture SparkPlan and send it to executors, which can be arbitrarily large.

Move code outside of the task lambda so that it doesn't capture SparkPlan.

### Why are the changes needed?
To reduce overhead of sending tasks to executors and avoid possible OOM on executors.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Rely on existing tests to verify functionality. I did not add new tests because there is no functional difference, just resource overhead.

### Was this patch authored or co-authored using generative AI tooling?
No


Original Author: timarmstrong